### PR TITLE
Adiciona Haaretz (Hebrew)

### DIFF
--- a/userscript/burlesco.user.js
+++ b/userscript/burlesco.user.js
@@ -53,6 +53,7 @@
 // @match        *://*.br18.com.br/*
 // @match        *://*.diariopopular.com.br/*
 // @match        *://*.haaretz.com/*
+// @match        *://*.haaretz.co.il/*
 // @webRequestItem {"selector":{"include":"*://paywall.folha.uol.com.br/*","exclude":"*://paywall.folha.uol.com.br/status.php"} ,"action":"cancel"}
 // @webRequestItem {"selector":"*://static.folha.uol.com.br/paywall/*","action":"cancel"}
 // @webRequestItem {"selector":"*://ogjs.infoglobo.com.br/*/js/controla-acesso-aux.js","action":"cancel"}
@@ -76,6 +77,8 @@
 // @webRequestItem {"selector":"*://*.jota.info/wp-content/themes/JOTA/assets/js/posts.js*","action":"cancel"}
 // @webRequestItem {"selector":"*://www.jornalvs.com.br/includes/js/paywall.js*","action":"cancel"}
 // @webRequestItem {"selector":"https://www.eltiempo.com/js/desktopArticle.js*","action":"cancel"}
+// @webRequestItem {"selector":"*://*.haaretz.co.il/*/inter.js","action":"cancel"}
+// @webRequestItem {"selector":"*://*.themarker.com/*/inter.js","action":"cancel"}
 // @run-at       document-start
 // @noframes
 // ==/UserScript==
@@ -266,7 +269,8 @@ document.addEventListener('DOMContentLoaded', function() {
     eraseAllCookies();
   }
 
-  else if (/haaretz\.com/.test(document.location.host)) {
+  else if (/haaretz\.com/.test(document.location.host) ||
+          (/haaretz\.co\.il/.test(document.location.host))) {
 
     GM_xmlhttpRequest({
       method: 'GET',

--- a/webext/background.js
+++ b/webext/background.js
@@ -140,6 +140,17 @@ const BLOCKLIST = {
       urlFilter: '*://*.haaretz.com/*'
     }
   },
+  haaretz_il: {
+    headerInjection: {
+      name: 'User-Agent',
+      value: 'Googlebot/2.1 (+http://www.googlebot.com/bot.html)',
+      urlFilter: '*://*.haaretz.co.il/*'
+    },
+    scriptBlocking: [
+      '*://*.haaretz.co.il/*/inter.js',
+      '*://*.themarker.com/*/inter.js'
+    ]
+  },
   pioneiro: {
     scriptBlocking: [
       '*://www.rbsonline.com.br/cdn/scripts/SLoader.js',

--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -94,7 +94,8 @@
     "*://www.jornalvs.com.br/*",
     "*://*.br18.com.br/*",
     "*://www.eltiempo.com/*",
-    "*://*.haaretz.com/*"
+    "*://*.haaretz.com/*",
+    "*://*.haaretz.co.il/*"
   ],
 
   "applications": {

--- a/webext/options.html
+++ b/webext/options.html
@@ -117,6 +117,12 @@
             </div>
             <div>
                 <label>
+                    <input type="checkbox" id="haaretz_il" checked>
+                    <span>Haaretz (Hebrew)</span>
+                </label>
+            </div>
+            <div>
+                <label>
                     <input type="checkbox" id="jornaldesantacatarina" checked>
                     <span>Jornal de Santa Catarina</span>
                 </label>

--- a/webext/options.js
+++ b/webext/options.js
@@ -15,6 +15,7 @@ const SITES = [
   'gauchazh',
   'gramophone',
   'haaretz',
+  'haaretz_il',
   'jornaldesantacatarina',
   'jornalnh',
   'jornalvs',


### PR DESCRIPTION
Notícia: https://www.haaretz.co.il/talkback/.premium-1.6609673  
Paywall: https://imgur.com/a/ef30kbZ  
Observação: O site em questão pode beneficiar uma pequena parcela ou nenhum dos usuários atuais, adicionei por que era uma versão em hebraico do jornal já adicionado (Ha'aretz), a única diferença deste para outro é que este detecta quando alteramos o user-agent para liberar a notícia, o problema foi resolvido bloqueando dois scripts.  
