### PR TITLE
Adiciona Diarinho

### DIFF
--- a/userscript/burlesco.user.js
+++ b/userscript/burlesco.user.js
@@ -77,7 +77,7 @@
 // @webRequestItem {"selector":"*://*.jota.info/wp-content/themes/JOTA/assets/js/posts.js*","action":"cancel"}
 // @webRequestItem {"selector":"*://www.jornalvs.com.br/includes/js/paywall.js*","action":"cancel"}
 // @webRequestItem {"selector":"https://www.eltiempo.com/js/desktopArticle.js*","action":"cancel"}
-// @webRequestItem {"selector":"*://*.diarinho.com.br/wp-admin/admin-ajax.php","action":"cancel"}
+// @webRequestItem {"selector":"*://diarinho.com.br/wp-admin/admin-ajax.php","action":"cancel"}
 // @run-at       document-start
 // @noframes
 // ==/UserScript==

--- a/userscript/burlesco.user.js
+++ b/userscript/burlesco.user.js
@@ -53,6 +53,7 @@
 // @match        *://*.br18.com.br/*
 // @match        *://*.diariopopular.com.br/*
 // @match        *://*.haaretz.com/*
+// @match        *://*.diarinho.com.br/*
 // @webRequestItem {"selector":{"include":"*://paywall.folha.uol.com.br/*","exclude":"*://paywall.folha.uol.com.br/status.php"} ,"action":"cancel"}
 // @webRequestItem {"selector":"*://static.folha.uol.com.br/paywall/*","action":"cancel"}
 // @webRequestItem {"selector":"*://ogjs.infoglobo.com.br/*/js/controla-acesso-aux.js","action":"cancel"}
@@ -76,6 +77,7 @@
 // @webRequestItem {"selector":"*://*.jota.info/wp-content/themes/JOTA/assets/js/posts.js*","action":"cancel"}
 // @webRequestItem {"selector":"*://www.jornalvs.com.br/includes/js/paywall.js*","action":"cancel"}
 // @webRequestItem {"selector":"https://www.eltiempo.com/js/desktopArticle.js*","action":"cancel"}
+// @webRequestItem {"selector":"*://*.diarinho.com.br/wp-admin/admin-ajax.php","action":"cancel"}
 // @run-at       document-start
 // @noframes
 // ==/UserScript==

--- a/webext/background.js
+++ b/webext/background.js
@@ -18,6 +18,11 @@ const BLOCKLIST = {
       '*://correio.rac.com.br/includes/js/novo_cp/fivewall.js*',
     ]
   },
+  diarinho: {
+    xhrBlocking: [
+      '*://*.diarinho.com.br/wp-admin/admin-ajax.php',
+    ]
+  },
   diariopopular: {
     cookieBlocking: {
       urlFilter: '*://www.diariopopular.com.br/*',

--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -94,7 +94,8 @@
     "*://www.jornalvs.com.br/*",
     "*://*.br18.com.br/*",
     "*://www.eltiempo.com/*",
-    "*://*.haaretz.com/*"
+    "*://*.haaretz.com/*",
+    "*://*.diarinho.com.br/*"
   ],
 
   "applications": {

--- a/webext/options.html
+++ b/webext/options.html
@@ -38,6 +38,12 @@
             </div>
             <div>
                 <label>
+                    <input type="checkbox" id="diarinho" checked>
+                    <span>Diarinho</span>
+                </label>
+            </div>
+            <div>
+                <label>
                     <input type="checkbox" id="diariocatarinense" checked>
                     <span>Diário Catarinense</span>
                 </label>

--- a/webext/options.js
+++ b/webext/options.js
@@ -2,6 +2,7 @@ const SITES = [
   'bloomberg',
   'br18',
   'correiopopular',
+  'diarinho',
   'diariocatarinense',
   'diariopopular',
   'exame',


### PR DESCRIPTION
Exemplo de notícia com paywall: https://diarinho.com.br/noticias/esporte/campeoes-do-surfuturo-sao-definidos/  
