### PR TITLE
Corrige O Globo e o Acervo

### DIFF
--- a/webext/background.js
+++ b/webext/background.js
@@ -134,8 +134,8 @@ const BLOCKLIST = {
     allowScript: [
       '*://cdn.tinypass.com/api/tinypass.min.js',
     ],
-    xhrBlocking:  [
-      '*://static.infoglobo.com.br/paywall/register-piano/*/scripts/nova-tela-register.js',
+    scriptBlocking: [
+      'https://static.infoglobo.com.br/paywall/js/tiny.js'
     ],
   },
   haaretz: {

--- a/webext/background.js
+++ b/webext/background.js
@@ -134,6 +134,9 @@ const BLOCKLIST = {
     allowScript: [
       '*://cdn.tinypass.com/api/tinypass.min.js',
     ],
+    xhrBlocking: [
+      '*://static.infoglobo.com.br/paywall/register-piano/*/scripts/nova-tela-register.js',
+    ],
     scriptBlocking: [
       'https://static.infoglobo.com.br/paywall/js/tiny.js'
     ],

--- a/webext/content-start.js
+++ b/webext/content-start.js
@@ -33,7 +33,37 @@ const INJECTION = {
           patchJs(script.src);
       });
     `
-  }
+  },
+  oglobo: {
+    url: /oglobo\.globo\.com/,
+    code: `
+      function patchJs(jsurl) {
+        var xhttp = new XMLHttpRequest();
+        xhttp.onreadystatechange = function() {
+          if (this.readyState == 4 && this.status == 200) {
+            var injectme = this.responseText;
+            injectme = injectme.replace('window.conteudoExclusivo?!0:!1', 'false');
+            var script = document.createElement("script");
+            script.type = "text/javascript";
+            var textNode = document.createTextNode(injectme);
+            script.appendChild(textNode);
+            document.head.appendChild(script);
+          }
+        };
+        xhttp.open("GET", jsurl, true);
+        xhttp.send();
+      }
+
+      document.addEventListener("DOMContentLoaded", function(event) {
+        var scripts = Array.from(document.getElementsByTagName('script'));
+        var script = scripts.find((el) => {
+          return el.src.includes('js/tiny.js')
+        });
+        if (script)
+          patchJs(script.src);
+      });
+    `
+  },
 };
 
 chrome.storage.local.get('sites', function(result) {

--- a/webext/content.js
+++ b/webext/content.js
@@ -18,13 +18,6 @@ const INJECTION = {
     url: /exame\.abril\.com\.br/,
     code: ABRIL_CODE
   },
-  oglobo: {
-    url: /oglobo\.globo\.com/,
-    code: `
-      document.body.setAttribute('style', 'overflow: scroll !important');
-      document.getElementById('barreiraRegisterExclusiva').remove();
-    `
-  },
   theeconomist: {
     url : /www\.economist\.com/,
     code: 'document.cookie = "ec_limit=allow";'

--- a/webext/manifest.json
+++ b/webext/manifest.json
@@ -20,7 +20,6 @@
       "run_at": "document_idle",
       "matches": [
         "*://www.bloomberg.com/*",
-        "*://*.oglobo.globo.com/*",
         "*://www.economist.com/*",
         "*://*.exame.abril.com.br/*",
         "*://foreignpolicy.com/*",
@@ -38,7 +37,10 @@
     {
       "js": ["content-start.js"],
       "run_at": "document_start",
-      "matches": ["*://gauchazh.clicrbs.com.br/*"]
+      "matches": [
+        "*://gauchazh.clicrbs.com.br/*",
+        "*://*.oglobo.globo.com/*"
+      ]
     }
   ],
 


### PR DESCRIPTION
Possivelmente relacionado com o #143, de qualquer forma, o paywall voltou a aparecer no Acervo o Globo e a correção também funciona para o resto do site.