### PR TITLE
Atualiza Nexo Jornal

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -86,12 +86,6 @@ const BLOCKLIST = {
       urlFilter: '*://www.jota.info/*'
     }
   },
-  nexo: {
-    cookieBlocking: {
-      urlFilter: '*://api.nexojornal.com.br/*',
-      blockAll: true
-    }
-  },
   nsctotal: {
     xhrBlocking: [
       'https://paywall.nsctotal.com.br/behaviors',

--- a/src/content-start.js
+++ b/src/content-start.js
@@ -80,6 +80,30 @@ const INJECTION = {
       });
     `
   },
+  nexo: {
+    url: /nexojornal\.com\.br/,
+    code: `
+      (function () {
+        let oldXHROpen = window.XMLHttpRequest.prototype.open;
+        window.XMLHttpRequest.prototype.open = function(method, url, async, user, password) {
+        if (url.includes('/paywall/access/')) {
+          Object.defineProperty(this, 'status', { writable: true });
+          Object.defineProperty(this, 'statusText', { writable: true });
+          this.status = 200;
+          this.statusText = 'OK';
+        }
+        return oldXHROpen.apply(this, arguments);
+        }
+      })();
+      (function () {
+        style = document.createElement('style');
+        style.type = 'text/css';
+        css='#aviso-metered-access {display: none !important}';
+        style.appendChild(document.createTextNode(css));
+        document.head.appendChild(style);
+      })();
+    `
+  },
 };
 
 chrome.storage.local.get('sites', function(result) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,7 +36,8 @@
         "*://gauchazh.clicrbs.com.br/*",
         "*://*.oglobo.globo.com/*",
         "*://*.dgabc.com.br/*",
-        "*://*.epoca.globo.com/*"
+        "*://*.epoca.globo.com/*",
+        "*://*.nexojornal.com.br/*"
       ]
     }
   ],


### PR DESCRIPTION
A API do Nexo retorna HTTP 200 ou 201 quando o usuário está permitido a consumir o conteúdo e HTTP 401 para o contrário. Removendo os cookies fazia a API retornar sempre positivo e após a atualização ela passou a sempre retornar 401 quando o limite de notícias fosse atingido. O controle não é feito por IP, o número de acessos é contabilizado por cookies mas o código da  sessão é passado como argumento na requisição para a API (o que não ocorria) e isso faz com que o paywall burle o burlesco (que atualmente trabalha removendo os cookies da requisição).

Para resolver o problema foi necessário dar um override no método open do objeto xmlhttprequest, interceptando todas as requisições, e  reimplementá-lo para alterar o status HTTP da response de 401 para 200 quando a requisição for feita à API. Também foi necessário ocultar com CSS o banner que aparece no início da tela contando o número de acessos gratuitos restantes.

Esta PR resolve a issue #214 