### PR TITLE
Atualiza paywall dos sites da Abril

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -134,7 +134,7 @@ const BLOCKLIST = {
   },
   veja: {
     scriptBlocking: [
-      '*://cdn.tinypass.com/api/tinypass.min.js',
+      'https://*.abril.com.br/wp-content/plugins/abril-plugins/abril-paywall/js/paywall.js*',
     ]
   },
 };

--- a/src/background.js
+++ b/src/background.js
@@ -36,7 +36,7 @@ const BLOCKLIST = {
   },
   exame: {
     scriptBlocking: [
-      '*://cdn.tinypass.com/api/tinypass.min.js',
+      '*://exame.com/wp-content/themes/exame-new/js/pywll.js',
     ]
   },
   folhadespaulo: {

--- a/src/background.js
+++ b/src/background.js
@@ -114,12 +114,12 @@ const BLOCKLIST = {
   },
   quatrorodas: {
     scriptBlocking: [
-      '*://cdn.tinypass.com/api/tinypass.min.js',
+      'https://*.abril.com.br/wp-content/plugins/abril-plugins/abril-paywall/js/paywall.js*',
     ]
   },
   superinteressante: {
     scriptBlocking: [
-      '*://cdn.tinypass.com/api/tinypass.min.js',
+      'https://*.abril.com.br/wp-content/plugins/abril-plugins/abril-paywall/js/paywall.js*',
     ]
   },
   uol: {

--- a/src/content.js
+++ b/src/content.js
@@ -1,8 +1,10 @@
 // run_at: document_idle
 const ABRIL_CODE = `
-  document.querySelector('body').classList.remove('disabledByPaywall')
-  document.querySelector('.piano-offer-overlay').remove()
-  document.querySelector('#piano_offer').remove()
+  window.setTimeout(function() {
+    document.querySelector('body').classList.remove('disabledByPaywall')
+    document.querySelector('.piano-offer-overlay').remove()
+    document.querySelector('#piano_offer').remove()
+  }, 10000)
 `;
 
 const INJECTION = {

--- a/src/content.js
+++ b/src/content.js
@@ -1,9 +1,8 @@
 // run_at: document_idle
 const ABRIL_CODE = `
-  document.querySelectorAll('.callpaywall')
-    .forEach(x => x.remove());
-  document.querySelectorAll('.content-blocked')
-    .forEach(x => x.classList.remove('content-blocked'))
+  document.querySelector('body').classList.remove('disabledByPaywall')
+  document.querySelector('.piano-offer-overlay').remove()
+  document.querySelector('#piano_offer').remove()
 `;
 
 const INJECTION = {

--- a/src/content.js
+++ b/src/content.js
@@ -24,7 +24,7 @@ const INJECTION = {
     `
   },
   exame: {
-    url: /exame\.abril\.com\.br/,
+    url: /exame\.com\.br/,
     code: ABRIL_CODE
   },
   folhadespaulo: {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,7 @@
       "js": ["content.js"],
       "run_at": "document_idle",
       "matches": [
-        "*://*.exame.abril.com.br/*",
+        "*://*.exame.com/*",
         "*://*.folha.uol.com.br/*",
         "*://*.folha.com.br/*",
         "*://super.abril.com.br/*",
@@ -72,7 +72,7 @@
     "*://api.tinypass.com/*",
     "*://cdn.tinypass.com/*",
     "*://dashboard.tinypass.com/*",
-    "*://*.exame.abril.com.br/*",
+    "*://exame.com/*",
     "*://super.abril.com.br/*",
     "*://veja.abril.com.br/*",
     "*://quatrorodas.abril.com.br/*",


### PR DESCRIPTION
Na Veja, foi adicionado uma remoção cosmética via content script, mas esse anti-paywall não é muito confiável porque precisa ser executado depois dele ter sido ativo, que pode demorar para acontecer. Como foi adicionado o bloqueio do script de paywall também, que impede o aviso de aparecer, provavelmente a remoção cosmética não será utilizada, mas continuará aí como fallback.

Os outros sites da Abril atualizados foram Quatro Rodas (não consegui ativar o paywall), SuperInteressante e Exame.

Corrige #279

Release 11.21 beta:
- [burlesco-chromium.zip](https://github.com/burlesco/burlesco/files/5252747/burlesco-chromium.zip)
- [burlesco-firefox.zip](https://github.com/burlesco/burlesco/files/5252748/burlesco-firefox.zip)

