### PR TITLE
adds support for theatlantic.com

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -176,6 +176,11 @@ const BLOCKLIST = {
     scriptBlocking: [
       '*://*.tinypass.com/*',
     ]
+  },
+  theatlantic: {
+    scriptBlocking: [
+      'https://cdn.theatlantic.com/_next/static/chunks/3235-ce2ff3f397931170.js'
+    ]
   }
 };
 


### PR DESCRIPTION
Hopefully it adds support for the news site theatlantic.com. I mean hopefully because I didn't find a way to run this version of the script in my tampermonkey.

As I could understand, you process all the files in order to create a single one and load it to the browser extension. I did install the dependencies with `npm i` and was able to run the included makefile, but could not find a single file in the dist folder in order to try to add to my tampermonkey.

It would be awesome if you could include a `CONTRIBUTING.md` file in the root folder with simple instruction in order to test the changes and see if they are working. This is a project I use a lot and would be happy if I can contribute more often.

Thanks a lot!